### PR TITLE
[Windows] Use an script to download the latest CI build exe at boot + Add automated CI Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,15 +18,19 @@ jobs:
           python-version: '3.12'
 
       - name: Bump version
-        if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          $NEW_VERSION="${{ github.ref_name }}"
-          (Get-Content troppical.py) -replace 'version = ".*"', "version = `"$NEW_VERSION`"" | Set-Content troppical.py
+          $NEW_VERSION="${{ github.sha }}"
+          # Update the version in main.py
+          (Get-Content main.py) -replace 'version = ".*"', "version = '$NEW_VERSION'" | Set-Content main.py
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add troppical.py
-          git commit -m "Update version to $NEW_VERSION"
-          git push origin HEAD:master --force --follow-tags --verbose
+          git add main.py
+          # Check if there are changes other than main.py
+          $CHANGES=$(git status --porcelain | Where-Object { $_ -notmatch 'main.py' })
+          if ($CHANGES) {
+            git commit -m "Update version to $NEW_VERSION"
+            git push origin HEAD:master --force --follow-tags --verbose
+          }
         shell: pwsh
 
       - name: Cache pip
@@ -92,3 +96,59 @@ jobs:
         with:
           name: troppical-android
           path: ./android/app/build/outputs/apk/release/app-release.apk
+  
+  create-release:
+    needs: [Windows-build, Android-build]
+    runs-on: ubuntu-latest
+#    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download artifact init_troppical
+        uses: actions/download-artifact@v3
+        with:
+          name: init-troppical-windows
+
+      - name: Download artifact troppical-android
+        uses: actions/download-artifact@v3
+        with:
+          name: troppical-android
+
+      - name: Extract artifacts
+        run: |
+          mkdir -p extracted/init_troppical
+          mkdir -p extracted/troppical-android
+          unzip init_troppical-windows -d extracted/init_troppical
+          unzip troppical-android -d extracted/troppical-android
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.sha }}
+          release_name: Release ${{ github.sha }}
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset init_troppical
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./extracted/init_troppical/init_troppical.exe
+          asset_name: init_troppical.exe
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Asset troppical-android
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./extracted/troppical-android/app-release.apk
+          asset_name: app-release.apk
+          asset_content_type: application/vnd.android.package-archive        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: troppical-windows
-          path: ${{ github.workspace }}/dist/troppical.exe
+          path: ${{ github.workspace }}/dist/main.exe
 
       - name: Upload init_troppical
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          pyinstaller --clean --onefile --icon=icon.ico --add-data "icon.ico;." --windowed troppical.py
+          pyinstaller --clean --onefile --icon=icon.ico --add-data "icon.ico;." --windowed main.py
           pyinstaller --clean --icon=icon.ico --windowed init_troppical.py
       - name: Upload troppical
         uses: actions/upload-artifact@v4
@@ -53,6 +53,11 @@ jobs:
           name: troppical-windows
           path: ${{ github.workspace }}/dist/troppical.exe
 
+      - name: Upload init_troppical
+        uses: actions/upload-artifact@v4
+        with:
+          name: init-troppical-windows
+          path: ${{ github.workspace }}/dist/init_troppical.exe
   Android-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |
           pyinstaller --clean --onefile --icon=icon.ico --add-data "icon.ico;." --windowed main.py
-          pyinstaller --clean --icon=icon.ico --windowed init_troppical.py
+          pyinstaller --clean --onefile --icon=icon.ico --windowed init_troppical.py
       - name: Upload troppical
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,16 +45,15 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          mkdir -p ${{ github.workspace }}/bin
           pyinstaller --clean --onefile --icon=icon.ico --add-data "icon.ico;." --windowed troppical.py
-
+          pyinstaller --clean --icon=icon.ico --windowed init_troppical.py
       - name: Upload troppical
         uses: actions/upload-artifact@v4
         with:
-          name: troppical-nightly
+          name: troppical-windows
           path: ${{ github.workspace }}/dist/troppical.exe
 
-  android-build:
+  Android-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,5 +85,5 @@ jobs:
       - name: Upload Android Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: app-release
+          name: troppical-android
           path: ./android/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,22 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      
+      - name: Get short SHA
+        id: sha
+        run: echo "::set-output name=short::$(git rev-parse --short ${{ github.sha }})"
 
       - name: Bump version
+        if: contains(github.event.head_commit.message, 'main.py')
         run: |
-          $NEW_VERSION="${{ github.sha }}"
+          $NEW_VERSION="${{ steps.sha.outputs.short }}"
           # Update the version in main.py
-          (Get-Content main.py) -replace 'version = ".*"', "version = '$NEW_VERSION'" | Set-Content main.py
+          (Get-Content main.py) -replace 'version = .*', "version = '$NEW_VERSION'" | Set-Content main.py
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add main.py
-          # Check if there are changes other than main.py
-          $CHANGES=$(git status --porcelain | Where-Object { $_ -notmatch 'main.py' })
-          if ($CHANGES) {
-            git commit -m "Update version to $NEW_VERSION"
-            git push origin HEAD:master --force --follow-tags --verbose
-          }
+          git commit -m "Update version to $NEW_VERSION"
+          git push origin HEAD:master --force --verbose
         shell: pwsh
 
       - name: Cache pip
@@ -97,46 +98,60 @@ jobs:
           name: troppical-android
           path: ./android/app/build/outputs/apk/release/app-release.apk
   
-  create-release:
+  Automated-Release:
     needs: [Windows-build, Android-build]
     runs-on: ubuntu-latest
-#    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download artifact init_troppical
-        uses: actions/download-artifact@v3
-        with:
-          name: init-troppical-windows
-
-      - name: Download artifact troppical-android
-        uses: actions/download-artifact@v3
-        with:
-          name: troppical-android
-
-      - name: Extract artifacts
+      - name: Download init_troppical-windows
         run: |
           mkdir -p extracted/init_troppical
+          curl -L -o init-troppical-windows.zip https://nightly.link/kleidis/Troppical/workflows/build/updater/init-troppical-windows.zip
+          unzip init-troppical-windows.zip -d extracted/init_troppical
+
+      - name: Download troppical-android
+        run: |
           mkdir -p extracted/troppical-android
-          unzip init_troppical-windows -d extracted/init_troppical
-          unzip troppical-android -d extracted/troppical-android
+          curl -L -o troppical-android.zip https://nightly.link/kleidis/Troppical/workflows/build/updater/troppical-android.zip
+          unzip troppical-android.zip -d extracted/troppical-android
+
+      - name: Get short SHA
+        id: sha
+        run: echo "::set-output name=short::$(git rev-parse --short ${{ github.sha }})"
+  
+      - name: Delete Existing Release
+        id: delete_release
+        run: |
+          release_id=$(gh release view ${{ steps.sha.outputs.short }} --json id --jq '.id' || echo "")
+          if [ -n "$release_id" ]; then
+            gh release delete ${{ steps.sha.outputs.short }} --yes
+          fi
+          tag_exists=$(git tag -l ${{ steps.sha.outputs.short }})
+          if [ -n "$tag_exists" ]; then
+            git push --delete origin ${{ steps.sha.outputs.short }}
+            git tag -d ${{ steps.sha.outputs.short }}
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUILD }}
 
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BUILD }}
         with:
-          tag_name: ${{ github.sha }}
-          release_name: Release ${{ github.sha }}
-          draft: true
+          tag_name: ${{ steps.sha.outputs.short }}
+          release_name: Troppical ${{ steps.sha.outputs.short }}
+          draft: false
           prerelease: false
 
       - name: Upload Release Asset init_troppical
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BUILD }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./extracted/init_troppical/init_troppical.exe
@@ -146,7 +161,7 @@ jobs:
       - name: Upload Release Asset troppical-android
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BUILD }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./extracted/troppical-android/app-release.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "::set-output name=short::$(git rev-parse --short ${{ github.sha }})"
 
       - name: Bump version
-        if: contains(github.event.head_commit.message, 'main.py')
+        if: github.ref == 'refs/heads/master' && contains(github.event.head_commit.message, 'main.py')
         run: |
           $NEW_VERSION="${{ steps.sha.outputs.short }}"
           # Update the version in main.py

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ citra_util.spec
 /__pycache__
 /dist
 troppical.spec
+.old

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ citra_util.spec
 /dist
 troppical.spec
 .old
+*.spec

--- a/README.md
+++ b/README.md
@@ -3,21 +3,18 @@
 </p>
 <p align="center" style="font-size:144px;">
   <strong>Troppical</strong>
+<p align="center">
+  <img src="https://img.shields.io/github/downloads/kleidis/Troppical/total" alt="GitHub all releases"/>
+  <a href="https://github.com/kleidis/Troppical/releases/latest">
+    <img src="https://img.shields.io/badge/Download-Latest_Release-2ea44f?logo=github&logoColor=white" alt="Download - Latest Release"/>
+  </a>  
 </h1>
 
 # What is this?
 
 Troppical is a simple app that lets you manage your emulators with an easy installation and updating process.
 
-**For now, we have these emulators**
-
-- Sudachi
-- Lime3DS
-- Citra Enhanced
-- PabloMK7's Citra fork
-- Panda3DS
-- Torzu (Windows only for now)
-- Strato (Android build (soon))
+**We have a wide range of emulators ranging from newer consoles like the Switch to retro ones like the SNES**
 
 If you'd like an emulator to be added, feel free to open a feature request issue. **Keep in mind that:**
 
@@ -26,13 +23,12 @@ If you'd like an emulator to be added, feel free to open a feature request issue
 
 # Downloading
 
-**[Troppical Windows](https://nightly.link/kleidis/Troppical/workflows/build/master/troppical-nightly.zip)**
-
-**[Troppical Android](https://nightly.link/kleidis/Troppical/workflows/build/master/app-release.zip)**
+Get `init_troppical.exe` for Windows or `troppical-android.apk` for Android from [Releases](https://github.com/kleidis/Troppical/releases)
 
 # Usage
 
- To use this app, select the emulator you want to install and follow the setup options.
+ To use this app, open init_troppical.exe if you're on Windows or `Troppical` from your app drawer if you;re on Android, select the emulator you want to install and follow the setup options.
+ - For Androdi you will need to give the app install permissions in order for Troppical to work 
 **You can have multiple emulators installed at the same time**
 
 **NOTES for the Windows version:**
@@ -40,13 +36,9 @@ If you'd like an emulator to be added, feel free to open a feature request issue
 - **Windows Defender might detect this application as a trojan/malware. This is not true at all, you can look at the source code and determine that it is not a valid claim,  the app isn't that complex.**
 **Please don't open an issue for this since there is nothing I can do apart from signing the app which I won't do**
 
-
-- The app is a portable executable so feel free to run it from any directory you wish
+- `init_troppical.exe` is a portable executable so feel free to run it from any directory or drive
 
 - Although Troppical is portable that doesn't mean the emulators are. For now, there is no way to move an emulator directory once it is installed. If you do so, Troppical will just install updates on the directory that you initially chose to install the respective emulator on. The Uninstall button will error out and prompt you to reinstall as well
-
-**REMEMBER:**
-- Troppical is in the beta stages of development. Things may break so please report any bugs you encounter and I;ll try my best to fix them. Note that this is my first project and I'm a beginner so please be patient
 
 # Screenshot
 ![Screenshot 2024-06-07 120452](https://github.com/kleidis/Troppical/assets/167202775/0e6d0c83-7132-414e-80dd-55dbc4ca9b29)
@@ -76,5 +68,10 @@ If you'd like an emulator to be added, feel free to open a feature request issue
 
 ### Compile:
 
-`pyinstaller --clean --onefile --icon=icon.ico --windowed troppical.py`
+- For main.py
+`pyinstaller --clean --onefile --icon=icon.ico --windowed main.py`
+
+- For init_troppical.py (This is just a script that downloads the latest compiled `main.py` exe from Github Actions and runs it)
+`pyinstaller --clean --onefile --icon=icon.ico --windowed init_troppical.py.py`
+
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Get `init_troppical.exe` for Windows or `troppical-android.apk` for Android from
 ### Compile:
 
 - For main.py
+
 `pyinstaller --clean --onefile --icon=icon.ico --windowed main.py`
 
 - For init_troppical.py (This is just a script that downloads the latest compiled `main.py` exe from Github Actions and runs it)
+
 `pyinstaller --clean --onefile --icon=icon.ico --windowed init_troppical.py.py`
 
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 </p>
 <p align="center" style="font-size:144px;">
   <strong>Troppical</strong>
-<p align="center">
-  <img src="https://img.shields.io/github/downloads/kleidis/Troppical/total" alt="GitHub all releases"/>
-  <a href="https://github.com/kleidis/Troppical/releases/latest">
-    <img src="https://img.shields.io/badge/Download-Latest_Release-2ea44f?logo=github&logoColor=white" alt="Download - Latest Release"/>
-  </a>  
 </h1>
 
 # What is this?
@@ -23,7 +18,7 @@ If you'd like an emulator to be added, feel free to open a feature request issue
 
 # Downloading
 
-Get `init_troppical.exe` for Windows or `troppical-android.apk` for Android from [Releases](https://github.com/kleidis/Troppical/releases)
+Get `init_troppical.exe` for Windows or `app-release.apk` for Android from [Releases](https://github.com/kleidis/Troppical/releases)
 
 # Usage
 

--- a/init_troppical.py
+++ b/init_troppical.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QApplication, QMessageBox
 import shutil
 
 def download_and_launch():
-    url = 'https://nightly.link/kleidis/Troppical/workflows/build/master/troppical-nightly.zip'
+    url = 'https://nightly.link/kleidis/Troppical/workflows/build/master/init-troppical-windows.zip'
     response = requests.get(url, stream=True)
     if response.status_code == 200:
         # Create a temporary file for the ZIP

--- a/init_troppical.py
+++ b/init_troppical.py
@@ -60,7 +60,7 @@ def main():
     app = QApplication(sys.argv)
     success = download_and_launch()
     if success:
-        QMessageBox.information(None, "Update Completed", "The updated version has been launched and cleaned up.")
+        QMessageBox.information(None, "Bye!", "Thanks for using Troppical.")
     sys.exit(app.exec())
 
 if __name__ == '__main__':

--- a/init_troppical.py
+++ b/init_troppical.py
@@ -1,0 +1,67 @@
+import sys
+import os
+import requests
+import tempfile
+import subprocess
+from zipfile import ZipFile
+from PyQt6.QtWidgets import QApplication, QMessageBox
+import shutil
+
+def download_and_launch():
+    url = 'https://nightly.link/kleidis/Troppical/workflows/build/master/troppical-nightly.zip'
+    response = requests.get(url, stream=True)
+    if response.status_code == 200:
+        # Create a temporary file for the ZIP
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.zip') as temp_zip:
+            for chunk in response.iter_content(chunk_size=8192):
+                temp_zip.write(chunk)
+
+        # Extract the ZIP file
+        with ZipFile(temp_zip.name, 'r') as zip_ref:
+            temp_dir = tempfile.mkdtemp()
+            zip_ref.extractall(temp_dir)
+
+        exe_path = None
+        for root, dirs, files in os.walk(temp_dir):
+            for file in files:
+                if file.lower().endswith('.exe'):
+                    exe_path = os.path.join(root, file)
+                    break
+            if exe_path:
+                break
+
+        if not exe_path:
+            QMessageBox.critical(None, "Execution Error", "Executable file not found in the archive.")
+            return False
+
+        # Display launching message
+        msg_box = QMessageBox()
+        msg_box.setIcon(QMessageBox.Icon.Information)
+        msg_box.setText("Troppical is initializing...")
+        msg_box.show()
+        QApplication.processEvents()
+
+        # Launch the downloaded executable
+        process = subprocess.Popen([exe_path], close_fds=True)
+        msg_box.close()
+
+        process.wait()
+
+        # Clean up the temporary files and directory
+        os.unlink(temp_zip.name)
+        shutil.rmtree(temp_dir) 
+
+        return True
+    else:
+        QMessageBox.critical(None, "Download Error", "Failed to download the update.")
+        return False
+
+def main():
+    app = QApplication(sys.argv)
+    success = download_and_launch()
+    if success:
+        QMessageBox.information(None, "Update Completed", "The updated version has been launched and cleaned up.")
+    sys.exit(app.exec())
+
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -13,12 +13,22 @@ import win32com.client
 import winreg
 from stylesheet import Style
 from pathlib import Path
+import subprocess
 
 class QtUi(QMainWindow, Style):
     def __init__(self):
         super().__init__()
         self.logic = Logic()
         self.logic.fetch_google_sheet_data()
+        # Show a message box indicating that Troppical is starting
+        self.loading_message_box = QMessageBox(self)
+        self.loading_message_box.setIcon(QMessageBox.Icon.Information)
+        self.loading_message_box.setText("Troppical is starting.... If you get a notifcation that Troppical is not responding, ignore it.")
+        self.loading_message_box.setWindowModality(Qt.WindowModality.ApplicationModal)
+        close_button = self.loading_message_box.addButton(QMessageBox.StandardButton.Close)
+        close_button.hide()
+        self.loading_message_box.show()
+        QApplication.processEvents()
         self.ui()  # Init UI
         self.load_stylesheet()
 
@@ -50,8 +60,9 @@ class QtUi(QMainWindow, Style):
         self.setMinimumSize(1000, 720)  # Set the minimum window size to 800x600
         # Set the window icon
         icon_path = os.path.join(sys._MEIPASS, 'icon.ico')
-        self.setWindowIcon(QIcon(icon_path))
+        self.setWindowIcon(QIcon())
         self.selection_page()
+
 
     # Emulator Select Page
     def selection_page(self):
@@ -224,7 +235,9 @@ class QtUi(QMainWindow, Style):
         finishLayout.addWidget(finishButton)
         # Add the progress bar page to the layout
         self.layout.addWidget(self.finishPage)  
-        
+
+        self.loading_message_box.close()
+
     def load_stylesheet(app):
             app.setStyleSheet(Style.dark_stylesheet)
             

--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ import win32com.client
 import winreg
 from stylesheet import Style
 from pathlib import Path
-import subprocess
 
 class QtUi(QMainWindow, Style):
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -347,7 +347,7 @@ class Logic:
         installed_emulator = self.updatevalue
         response = requests.get(self.releases_url + "/latest")
         latest_release = response.json()
-        latest_version = latest_release['tag_name']
+        latest_tag = latest_release['tag_name']
 
         # Check for specific emulators that use a rolling-release
         if self.emulator in ['Vita3K', 'NooDS']:
@@ -360,8 +360,8 @@ class Logic:
             else:
                 pass
 
-        if latest_version > installed_emulator:
-            reply = QMessageBox.question(qtui, "Update Found", "Would you like to update " + self.emulator + " to " +  latest_version + "?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        if latest_tag > installed_emulator:
+            reply = QMessageBox.question(qtui, "Update Found", "Would you like to update " + self.emulator + " to " +  latest_tag + "?", QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
             if reply == QMessageBox.StandardButton.Yes:
                 self.install_mode = "Update"
                 qtui.layout.setCurrentIndex(3)


### PR DESCRIPTION
This PR changes `troppical.py` to `main.py` and adds init_troppical.py which downloads the latest exe from Github Actions
This was done since we are moving to a rolling release model by adding an automated CI release job

This way users don't have to think about updating Troppical manually at least on Windows (Which is important since we add fixes that they might need if a new emulator is added)
