### PR TITLE
Add a pip requirements text file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+PyQt6
+requests
+pywin32

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt6
 requests
 pywin32
+pyinstaller


### PR DESCRIPTION
The requirements file simplifies installing dependencies. You don't need to type out a long command anymore, just add the dependencies to a text file and do ``pip -r <text-file>``. You can also add in specific versions to each entry in the list.

[Here](https://pip.pypa.io/en/stable/reference/requirements-file-format/) is further documentation on the pip requirements file.

I had a look at ``main.py`` and noted down the dependencies that weren't part of the standard set of modules into ``requirements.txt``. I may have missed a few so please let me know if I have.

I have added these modules to the file:
```
PyQt6
requests
pywin32
pyinstaller
```